### PR TITLE
Fix tap highlight issue on paper-icon-button

### DIFF
--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -79,6 +79,7 @@ you should ensure that the `aria-label` attribute is set.
         position: relative;
         padding: 8px;
         outline: none;
+        -webkit-tap-highlight-color: rgba(0,0,0,0);
         -webkit-user-select: none;
         -moz-user-select: none;
         -ms-user-select: none;


### PR DESCRIPTION
Screenshot of current broken behavior of paper-icon-button: http://i.imgur.com/Hsl856m.png

The UA adds an ugly square around the button when pressed to 'give faster touch feedback'. Since we have the ripples this is unnecessary. It is disabled on Blink and Webkit with -webkit-tap-highlight-color: rgba(0,0,0,0);

There is currently no solution for Mozilla and IE's fix requires a metatag which I'm not sure how to do in a way that fits into the web components approach.