### PR TITLE
Subtle ripple positioning fix

### DIFF
--- a/paper-icon-button.html
+++ b/paper-icon-button.html
@@ -94,6 +94,7 @@ you should ensure that the `aria-label` attribute is set.
       }
 
       #ripple {
+        border-radius: 50%;
         pointer-events: none;
         z-index: -1;
       }


### PR DESCRIPTION
This is extremely subtle, but currently when a ripple occurs it is clipped harshly against the square outline of the button, giving away that the icon is actually a square element. 

Adding border-radius: 50% to the ripple on icon-buttons causes their ripple to be clipped against the ripple circle, avoiding the harsh clipping and maintaining the illusion that the icon is just an icon with a pretty ripple, not actually an icon in a square box.