### PR TITLE
Prevent visual glitching of demo with .hover set

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -34,6 +34,8 @@ license that can be found in the LICENSE file.
 
       paper-icon-button {
         vertical-align: middle;
+        /* This border-radius is neccessary for any button which may later gain the .hover class to prevent visual glitching */
+        border-radius: 50%;
       }
 
       paper-icon-button.hover:hover {


### PR DESCRIPTION
Right now moving the cursor slowly in from the corner of the icon with .hover set causes visual glitching:

Hovering changes the border-radius to 50%, but this changes the hover area so the next pixel move of the cursor will be outside of the element and will unset .hover. This causes the background to flicker.

Setting border-radius: 50% on any element which will become border-radius: 50% on hover is therefore necessary. 

Note it may be possible to achieve the same affect by setting a child div to border-radius: 50% on hover and ensuring the outside element's size remains the same, but I believe this will require wrapping the button in another div or introducing pseudo-elements which I'm not an expert in.

Note I am a Google employee on the Chrome team.